### PR TITLE
Added support for custom header serializer

### DIFF
--- a/Rebus.Msmq.Tests/Contracts/MsmqTransportInspectorFactory.cs
+++ b/Rebus.Msmq.Tests/Contracts/MsmqTransportInspectorFactory.cs
@@ -7,7 +7,7 @@ namespace Rebus.Msmq.Tests.Contracts
     {
         public TransportAndInspector Create(string address)
         {
-            var transport = new MsmqTransport(address, new ConsoleLoggerFactory(false));
+            var transport = new MsmqTransport(address, new ConsoleLoggerFactory(false), new ExtensionHeaderSerializer());
             var transportInspector = new MsmqTransportInspector(address);
 
             return new TransportAndInspector(transport, transportInspector);

--- a/Rebus.Msmq.Tests/MsmqTransportFactory.cs
+++ b/Rebus.Msmq.Tests/MsmqTransportFactory.cs
@@ -19,7 +19,7 @@ namespace Rebus.Msmq.Tests
 
         public ITransport Create(string inputQueueAddress)
         {
-            var transport = new MsmqTransport(inputQueueAddress, new ConsoleLoggerFactory(true));
+            var transport = new MsmqTransport(inputQueueAddress, new ConsoleLoggerFactory(true), new ExtensionHeaderSerializer());
 
             _disposables.Add(transport);
 

--- a/Rebus.Msmq.Tests/TestMsmqIgnoreMangledMessage.cs
+++ b/Rebus.Msmq.Tests/TestMsmqIgnoreMangledMessage.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Messaging;
+using System.Text;
+using System.Threading;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Messages;
+using Rebus.Tests.Contracts;
+using Message = System.Messaging.Message;
+
+namespace Rebus.Msmq.Tests
+{
+    [TestFixture]
+    [Description("Verify that serializer can ignore mangled message")]
+    public class TestMsmqIgnoreMangledMessage : FixtureBase
+    {
+        readonly string _inputQueueName = TestConfig.GetName("mangled-message");
+
+        protected override void SetUp()
+        {
+            MsmqUtil.Delete(_inputQueueName);
+
+            Configure.With(Using(new BuiltinHandlerActivator()))
+                .Transport(t => t.UseMsmq(_inputQueueName))
+                .Options(opt =>
+                {
+                    opt.Decorate<IMsmqHeaderSerializer>(p => new MangledMessageIngoreSerializer());
+                })
+                .Start();
+        }
+
+        [Test]
+        public void MangledMessageIsReceived()
+        {
+            using (var messageQueue = new MessageQueue(MsmqUtil.GetPath(_inputQueueName)))
+            {
+                var transaction = new MessageQueueTransaction();
+                transaction.Begin();
+                messageQueue.Send(new Message
+                {
+                    Extension = Encoding.UTF32.GetBytes("this is definitely not valid UTF8-encoded JSON")
+                }, transaction);
+                transaction.Commit();
+            }
+
+            Thread.Sleep(5000);
+
+            CleanUpDisposables();
+
+            using (var messageQueue = new MessageQueue(MsmqUtil.GetPath(_inputQueueName)))
+            {
+                messageQueue.MessageReadPropertyFilter = new MessagePropertyFilter
+                {
+                    Extension = true
+                };
+
+                Assert.Catch<MessageQueueException>(() => messageQueue.Receive(TimeSpan.FromSeconds(2)));
+            }
+        }
+    }
+
+    public class MangledMessageIngoreSerializer : IMsmqHeaderSerializer
+    {
+        public void SerializeToMessage(Dictionary<string, string> headers, Message msmqMessage)
+        {
+        }
+
+        public Dictionary<string, string> Deserialize(Message msmqMessage)
+        {
+            return new Dictionary<string, string>() { { Headers.MessageId, msmqMessage.Id } };
+        }
+    }
+}

--- a/Rebus.Msmq.Tests/TestMsmqTransport.cs
+++ b/Rebus.Msmq.Tests/TestMsmqTransport.cs
@@ -478,7 +478,7 @@ namespace Rebus.Msmq.Tests
 
         static List<int> SendMessages(int messageCount)
         {
-            var transport = new MsmqTransport(QueueName, new ConsoleLoggerFactory(true));
+            var transport = new MsmqTransport(QueueName, new ConsoleLoggerFactory(true), new ExtensionHeaderSerializer());
 
             MsmqUtil.EnsureQueueExists(MsmqUtil.GetPath(QueueName));
 

--- a/Rebus.Msmq.Tests/TestMsmqTransportMachineAddressing.cs
+++ b/Rebus.Msmq.Tests/TestMsmqTransportMachineAddressing.cs
@@ -22,7 +22,7 @@ namespace Rebus.Msmq.Tests
 
         protected override void SetUp()
         {
-            _transport = new MsmqTransport(_queueName, new ConsoleLoggerFactory(true));
+            _transport = new MsmqTransport(_queueName, new ConsoleLoggerFactory(true), new ExtensionHeaderSerializer());
             _transport.CreateQueue(_queueName);
 
             Using(_transport);

--- a/Rebus.Msmq.Tests/TestMsmqUtil.cs
+++ b/Rebus.Msmq.Tests/TestMsmqUtil.cs
@@ -47,7 +47,7 @@ namespace Rebus.Msmq.Tests
 
         static async Task SendMessageTo(string queueName)
         {
-            using (var transport = new MsmqTransport(queueName, new ConsoleLoggerFactory(false)))
+            using (var transport = new MsmqTransport(queueName, new ConsoleLoggerFactory(false), new ExtensionHeaderSerializer()))
             {
                 using (var scope = new RebusTransactionScope())
                 {

--- a/Rebus.Msmq/Config/MsmqTransportConfigurationExtensions.cs
+++ b/Rebus.Msmq/Config/MsmqTransportConfigurationExtensions.cs
@@ -23,7 +23,8 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var transport = new MsmqTransport(inputQueueName, rebusLoggerFactory);
+                var extensionDeserializer = c.Has<IMsmqHeaderSerializer>(false) ? c.Get<IMsmqHeaderSerializer>() : new ExtensionHeaderSerializer();
+                var transport = new MsmqTransport(inputQueueName, rebusLoggerFactory, extensionDeserializer);
                 builder.Configure(transport);
                 return transport;
             });
@@ -39,11 +40,11 @@ namespace Rebus.Config
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
 
             var builder = new MsmqTransportConfigurationBuilder();
-
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var transport = new MsmqTransport(null, rebusLoggerFactory);
+                var extensionDeserializer = c.Has<IMsmqHeaderSerializer>(false) ? c.Get<IMsmqHeaderSerializer>() : new ExtensionHeaderSerializer();
+                var transport = new MsmqTransport(null, rebusLoggerFactory, extensionDeserializer);
                 builder.Configure(transport);
                 return transport;
             });

--- a/Rebus.Msmq/Msmq/IMsmqHeaderSerializer.cs
+++ b/Rebus.Msmq/Msmq/IMsmqHeaderSerializer.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Messaging;
+
+namespace Rebus.Msmq
+{
+    /// <summary>
+    /// Interface for msmq header serialization
+    /// </summary>
+    public interface IMsmqHeaderSerializer
+    {
+        /// <summary>
+        /// Serialize header to msmq-message
+        /// </summary>
+        void SerializeToMessage(Dictionary<string, string> headers, Message msmqMessage);
+
+        /// <summary>
+        /// Deserialize header to key/value-pair.
+        /// </summary>
+        /// <param name="msmqMessage">msmq-message</param>
+        /// <returns>Deserialized headers</returns>
+        Dictionary<string, string> Deserialize(Message msmqMessage);
+    }
+}

--- a/Rebus.Msmq/Msmq/MsmqHeaderSerializer.cs
+++ b/Rebus.Msmq/Msmq/MsmqHeaderSerializer.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Messaging;
+using System.Text;
+using Rebus.Serialization;
+
+namespace Rebus.Msmq
+{
+    /// <summary>
+    /// Header serializer based on extension
+    /// </summary>
+    public class ExtensionHeaderSerializer : IMsmqHeaderSerializer
+    {
+        readonly HeaderSerializer _utf8HeaderSerializer = new HeaderSerializer { Encoding = Encoding.UTF8 };
+
+        /// <summary>
+        /// Serializes headers to the extension property of the msmq-message
+        /// </summary>
+        public void SerializeToMessage(Dictionary<string, string> headers, Message msmqMessage)
+        {
+            msmqMessage.Extension = _utf8HeaderSerializer.Serialize(headers);
+        }
+
+        /// <summary>
+        /// Deserialize msmq-message from the extension property
+        /// </summary>
+        public Dictionary<string, string> Deserialize(Message msmqMessage)
+        {
+            return _utf8HeaderSerializer.Deserialize(msmqMessage.Extension);
+        }
+
+    }
+}


### PR DESCRIPTION
I've added support for the MsmqTransport layer to use a customized header serializer. The purpose is to enable messages not coming from rebus to be handled through a custom message serializer, but since these messages do not have the headers serialized to the extension property I need to be able to use a different serializer for the headers.